### PR TITLE
Editorial updates

### DIFF
--- a/draft-regext-rdap-extensions.md
+++ b/draft-regext-rdap-extensions.md
@@ -548,10 +548,6 @@ identifier (see (#bare_extension)).  IETF-defined RDAP extensions that
 do not follow this guidance MUST describe why it is not being
 followed.
 
-In addition, RDAP extensions defined by the IETF are allowed to define
-new types in the RDAP JSON Values Registry (see
-(#rdap_json_values_registry)).
-
 # Extension Implementer Considerations {#extension_implementer_considerations}
 
 ## Redirects {#redirects_implementer}

--- a/draft-regext-rdap-extensions.md
+++ b/draft-regext-rdap-extensions.md
@@ -181,13 +181,7 @@ compatibility with variable names in programming languages and
 transliteration with XML.
 
 RDAP extension identifiers have no explicit structure, and are opaque
-insofar as no inner-meaning can be "seen" in them.  This document
-restricts the syntax of RDAP extension identifiers from containing two
-consecutive "_" (underscore) characters, reserving their use for the
-future definition of structure (such as for a versioning scheme). That
-is, RDAP extensions MUST NOT define an identifier with two consecutive
-underscore characters ("__") unless explicitly adhering to an RFC
-describing such usage.
+insofar as no inner-meaning can be "seen" in them.
 
 RDAP extensions MUST NOT define an extension identifier that when
 prepended to an underscore character may collide with an existing
@@ -493,7 +487,7 @@ class, and use the extension's identifier as the object class name.
 
 ### rdapConformance Population
 
-[@!RFC9083, Section 4.1] offers the following guidance on including
+[@!RFC9083, section 4.1] offers the following guidance on including
 extension identifiers in the "rdapConformance" member of an RDAP
 response:
 
@@ -513,7 +507,7 @@ content within the JSON, and each extension identifier MUST be free
 from conflict with the other identifiers with respect to their syntax
 and semantics.
 
-Note that this document does not update the guidance from [@!RFC9083, Section 4.1]
+Note that this document does not update the guidance from [@!RFC9083, section 4.1]
 regarding "/help" responses and the "rdapConformance" array.
 
 When a server implementation supports multiple extensions, it is
@@ -565,7 +559,7 @@ new types in the RDAP JSON Values Registry (see
 [@!RFC7480] describes the use of redirects in RDAP. Redirects are prominent
 in the discovery of authoritative RIR servers, as the process outlined in
 [@!RFC9224], which uses IANA allocations, does not account for transfers of
-resources between RIRs. [@!RFC7480, Section 4.3] instructs servers to ignore
+resources between RIRs. [@!RFC7480, section 4.3] instructs servers to ignore
 unknown query parameters. As it relates to issuing URLs for redirects, servers
 MUST NOT blindly copy query parameters from a request to a redirect URL as
 query parameters may contain sensitive information, such as security credentials,
@@ -644,9 +638,8 @@ consultation of the definition of "fizzbuzz_1" will determine its
 relationship with "fizzbuzz_0". Additionally, "fizzbuzz_99" may be the
 predecessor of "fizzbuzz_0".
 
-If a future RFC defines a versioning scheme (such as using the
-mechanism defined in (#syntax)), an RDAP extension definition MUST
-explicitly denote its compliance with that scheme.
+If a future RFC defines a versioning scheme, an RDAP extension
+definition MUST explicitly denote its compliance with that scheme.
 
 ### Backwards-Compatible Changes {#backwards_compatible_changes}
 
@@ -767,7 +760,7 @@ extension registration must have another expert reviewer double-check any
 submitted registration.
 
 Expert reviewers are to use the following criteria for extensions
-defined in this document, [!@RFC7480], [!@RFC9082], and [!@RFC9083].
+defined in this document, [@!RFC7480], [@!RFC9082], and [@!RFC9083].
 The following is a summary checklist:
 
 1. Does the extension define an extension identifier following the naming
@@ -796,7 +789,7 @@ of their extension by sending a request for review to regext@ietf.org.
 
 ## RDAP JSON Values Registry {#rdap_json_values_registry}
 
-[@!RFC9083, Section 10.2] defines the [RDAP JSON Values Registry in IANA]
+[@!RFC9083, section 10.2] defines the [RDAP JSON Values Registry in IANA]
 (https://www.iana.org/assignments/rdap-json-values/rdap-json-values.xhtml).
 This registry contains values to be used in the JSON values of RDAP responses.
 Registrations into this registry may occur in IETF-defined RDAP extensions
@@ -812,7 +805,7 @@ the IETF and other IETF specifications MAY define additional value
 types (the "type" field).  These specifications MUST describe the
 specific JSON field to be used for each new value type.
 
-[@!RFC9083, Section 10.2] defines the criteria for the values. Of these, criteria two
+[@!RFC9083, section 10.2] defines the criteria for the values. Of these, criteria two
 states:
 
 > Values must be strings. They should be multiple words separated by single
@@ -843,13 +836,13 @@ and ideally four or five. An expert reviewer assigned to the review of an RDAP
 JSON values registration must have another expert reviewer double-check any
 submitted registration.
 
-Expert reviewers are to use the criteria defined in [@!RFC9083, Section 10.2].
+Expert reviewers are to use the criteria defined in [@!RFC9083, section 10.2].
 
 # Security Considerations {#security_considerations}
 
 (#usage_in_query_parameters) describes the usage of query parameters and (#redirects_author) describes
 the restrictions extensions must follow to use them.
-[@!RFC7480, Section 4.3] instructs servers to ignore
+[@!RFC7480, section 4.3] instructs servers to ignore
 unknown query parameters. As it relates to issuing URLs for redirects, servers
 MUST NOT blindly copy query parameters from a request to a redirect URL as
 query parameters may contain sensitive information, such as security credentials

--- a/draft-regext-rdap-extensions.md
+++ b/draft-regext-rdap-extensions.md
@@ -54,144 +54,236 @@ Domain Name Registries (DNRs), Regional Internet Registries
 RDAP queries are defined in [@!RFC9082] and RDAP responses are defined
 in [@!RFC9083].
 
-RDAP contains a means to define extensions for queries not found in [@!RFC9082] and
-responses not found in [@!RFC9083]. RDAP extensions are also described in [@!RFC7480].
-This document uniformly describes RDAP extensions, clarifies their usage, and
-defines additional semantics that were previously undefined or ambiguous.
+RDAP contains a means to define extensions for queries not found in
+[@!RFC9082] and responses not found in [@!RFC9083]. RDAP extensions
+are also described in [@!RFC7480].  This document describes the
+requirements for RDAP extension definition and use, clarifying
+ambiguities and defining additional semantics and options that were
+previously implicit.
 
 ## Summary of Updates
 
 This document updates [@!RFC7480], [@!RFC9082], and [@!RFC9083] in the following
 areas:
 
-1. (#extension_identifier) provides additional guidance on RDAP extension identifiers,
-   registration of identifiers for the purpose of avoiding namespace collisions,
-   and reserves a specific syntax for future use.
-1. (#usage_in_queries) clarifies the usage of extension identifiers in RDAP URLs and formally defines
+1. (#purpose) provides additional guidance on the purpose
+   of RDAP extension identifiers, including their registration for the
+   purpose of avoiding namespace collisions, as well as for signaling
+   server policy/behavior.
+1. (#syntax) reserves a specific identifier syntax for future use.
+1. (#usage_in_requests) clarifies the usage of extension identifiers in RDAP URLs and formally defines
    their usage with child path segments and query parameters.
-1. (#usage_in_json) clarifies the usage of extension identifiers in JSON.
-1. (#object_classes_in_extensions) and (#search_results_in_extensions) disambiguates the definition
-   of new object classes and search results by extensions in [@!RFC9082]. 
-1. This document describes the various styles and kinds of RDAP extensions
-   and their extension identifiers.
-1. This document describes extension versioning and changes to extensions
-   that would make them incompatible or compatible with previous versions of an extension.
-1. (#redirects) and (#referrals) discusses the uses of extensions with regard
-   to RDAP redirects and referrals, including security and privacy considerations.
-1. This document provides guidance to extension authors regarding the creation of extension specification.
+1. (#usage_in_responses) clarifies the usage of extension identifiers
+   in responses, including for new object classes and search result arrays.
+1. (#extension_implementer_considerations) documents behavior
+   considerations for extension implementers.
+1. (#extension_author_considerations) documents behavior
+   considerations for extension developers, covering
+   redirects ((#redirects_author)), referrals ((#referrals)), and versioning
+   ((#versioning)).
+1. (#existing_extension_registrations) documents existing extensions that
+   were not registered in accordance with the requirements from
+   the relevant RDAP documents ([@!RFC7480], [@!RFC9082], and
+   [@!RFC9083]).
 1. (#rdap_extensions_registry) and (#rdap_json_values_registry) provide further
    guidance on registrations into the IANA RDAP registries and recommendations
    for the expert review processes for these registries.
 
 ## Document Terms
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
 "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
 "MAY", and "OPTIONAL" in this document are to be interpreted as
 described in [@!BCP14] when, and only when, they
 appear in all capitals, as shown here.
 
-# The RDAP Extension Identifier {#extension_identifier}
+# Identifiers {#identifiers}
 
-[@!RFC7480, section 6] describes the identifier used to signify RDAP extensions
-and the IANA registry into which RDAP extensions are to be registered.
+## Purpose {#purpose}
 
-In brief, RDAP extensions identifiers start with an alphabetic character and may
-contain alphanumeric characters and "_" (underscore) characters. This formulation
-was explicitly chosen to allow compatibility with variable names in programming
-languages and transliteration with XML.
+[@!RFC7480, section 6] describes the identifier used to signify RDAP
+extensions and the IANA registry into which RDAP extensions are to be
+registered.
 
-When in use in RDAP, extension identifiers are prepended to URL path segments,
-URL query parameters, and JSON object member names (herein further referred to 
-as "JSON names").  In all cases, the extension identifier acts as a namespace
-preventing collisions between extension elements.
+When in use in RDAP, extension identifiers are prepended to URL path
+segments, URL query parameters, and JSON object member names (herein
+further referred to as "JSON names").  They are also included in the
+"rdapConformance" member of each response that relies on the
+extension, so that clients can determine the extensions being used by
+the server for that response.  The "/help" response returns an
+"rdapConformance" member containing the identifiers for all extensions
+used by the server.
 
-Additionally, implementers and operators can use the extension identifiers
-to find an extensions definition (via the IANA registry).
+The main purpose of the extension identifier is to act as a namespace,
+preventing collisions between elements from different extensions.
+Additionally, implementers and operators can use the extension
+identifiers to find extension definitions via an IANA registry.
 
-RDAP extension identifiers have no explicit structure and are opaque in that no
-inner-meaning can be "seen" in them. This document restricts the syntax
-of RDAP extension identifiers from containing two consecutive "_" (underscore)
-characters and reserves their use for the future definition of structure (such
-as to define a versioning scheme). That is, RDAP extensions MUST NOT define
-an identifier with two consecutive underscore characters ("__") unless explicitly
-adhering to an RFC describing such usage.
+### Profile and Marker Extensions {#profiles_and_markers}
 
-RDAP extensions MUST NOT define an extension identifier that when prepended to
-an underscore character may collide with an existing extension identifier.
-For example, if there were a pre-existing identifier of "foo_bar", another extension 
-could not define the identifier "foo". Likewise, if there were a pre-existing
-identifier of "foo_bar", another extension could not define the identifier "foo_bar_buzz".
-However, an extension could define "foo" if "foobar" pre-existed and vice versa.
+While the RDAP extension mechanism was created to extend RDAP queries
+and/or responses, extensions can also be used to signal server policy
+(for example, specifying the conditions of use for existing response
+structures). Extensions that are primarily about signaling server
+policy are often called "profiles".
 
-For this reason, usage of an underscore character in RDAP extension identifiers
-is NOT RECOMMENDED. Implementers should be aware that many existing extension
-identifiers do contain underscore characters.
+Some extensions exist to denote the usage of values placed into an
+IANA registry, such as the IANA RDAP registries, or the usage of
+extensions for specifications used in RDAP responses, such as extended
+vCard/jCard properties.  Such extensions exist to "mark" these usages
+and are often called "marker" extensions.
 
-[@!RFC7480] does not explicitly state that extension identifiers are case-sensitive.
-This document updates the formulation in [@!RFC7480] to explicitly note that extension
-identifiers are case-sensitive, and extension identifiers MUST NOT be registered
-where a new identifier is a mixed-case version of an existing identifier. For example,
-if "lunarNIC" is already registered as an identifier, a new registration with "lunarNic"
-(note the lowercase if "ic" in "Nic") is not allowed.
+For example, an extension may be used to signal desired processing of
+a "rel" attribute in a "links" array, where the "rel" value is
+registered in the Link Relations Registry
+(<https://www.iana.org/assignments/link-relations/link-relations.xhtml>):
 
-# Usage in Queries {#usage_in_queries}
+    {
+      "rdapConformance": [
+        "rdap_level_0",
+        "lunarNIC"
+      ],
+      "objectClassName": "domain",
+      "ldhName": "example.com",
+      "links": [
+        {
+          "value": "https://example.com/domain/example.com",
+          "href": "https://example.com/sideways_href",
+          "rel": "sideways",
+          "type": "application/rdap+json"
+        }
+      ]
+    }
 
-[@!RFC9082, section 5] describes the use of extension identifiers in formulating
-URIs to query RDAP servers. The extension identifiers are to be prepended to the
-path segments they use. For example, if an extension uses the identifier
-"foobar", then the path segments used in that extension are prepended with "foobar_".
-If the "foobar" extension defines paths "fizz" and "fazz", the URIs for this
-extension might take the following form:
+When defining the usage of link relations, extensions should specify
+the media types expected to be used with those link relations.
+
+Regardless of the category of the extension, its usage may also
+leverage the appearance of its identifier in the "rdapConformance"
+array.  Clients may use the "/help" query as defined in [@!RFC9082] to
+discover the extensions in use by the server.
+
+### Multiple Identifiers in Single Extension
+
+Extension specifications have customarily defined only one extension
+identifier.  However, there is no explicit limit on the number of
+extension identifiers that may be defined in a single extension
+specification.  The main reason for defining multiple identifiers is
+to reserve multiple namespaces in URLs or responses: see e.g.
+[@?I-D.ietf-regext-rdap-rir-search].
+
+## Syntax
+
+In brief, RDAP extension identifiers start with an alphabetic
+character and may contain alphanumeric characters and "_" (underscore)
+characters. This formulation was explicitly chosen to allow
+compatibility with variable names in programming languages and
+transliteration with XML.
+
+RDAP extension identifiers have no explicit structure, and are opaque
+insofar as no inner-meaning can be "seen" in them.  This document
+restricts the syntax of RDAP extension identifiers from containing two
+consecutive "_" (underscore) characters, reserving their use for the
+future definition of structure (such as for a versioning scheme). That
+is, RDAP extensions MUST NOT define an identifier with two consecutive
+underscore characters ("__") unless explicitly adhering to an RFC
+describing such usage.
+
+RDAP extensions MUST NOT define an extension identifier that when
+prepended to an underscore character may collide with an existing
+extension identifier.  For example, if there were a pre-existing
+identifier of "foo_bar", another extension could not define the
+identifier "foo". Likewise, if there were a pre-existing identifier of
+"foo_bar", another extension could not define the identifier
+"foo_bar_buzz".  However, an extension could define "foo" if there
+were a pre-existing definition of "foobar", and vice versa.
+
+For this reason, usage of an underscore character in RDAP extension
+identifiers is NOT RECOMMENDED. Implementers should be aware that many
+existing extension identifiers do contain underscore characters.
+
+[@!RFC7480] does not explicitly state that extension identifiers are
+case-sensitive.  This document updates the formulation in [@!RFC7480]
+to explicitly note that extension identifiers are case-sensitive, and
+extension identifiers MUST NOT be registered where a new identifier is
+a mixed-case version of an existing identifier. For example, if
+"lunarNIC" is already registered as an identifier, a new registration
+with "lunarNic" (note the lowercase if "ic" in "Nic") would not be
+allowed.
+
+## Usage in Requests {#usage_in_requests}
+
+### Usage in Paths {#usage_in_paths}
+
+[@!RFC9082, section 5] describes the use of extension identifiers in
+formulating URLs to query RDAP servers. The extension identifiers are
+to be prepended to the path segments they use. For example, if an
+extension uses the identifier "foobar", then the path segments used in
+that extension are prepended with "foobar_".  If the "foobar"
+extension defines paths "fizz" and "fazz", the URLs for this extension
+would be like so:
 
     https://base.example/foobar_fizz
     https://base.example/foobar_fazz
 
-While [@!RFC9082] describes the extension identifier as a prepended string to a
-path segment, it does not describe the usage of the extension identifier as a path
-segment which may have child path segments. This document updates [@!RFC9082] to
-allow the usage of extension identifiers as path segments which may have child path
-segments. For example, if the "foobar" extension defines the child paths "fizz" and "fazz",
-the URIs for this extension would take the following forms:
+While [@!RFC9082] describes the extension identifier as a prepended
+string to a path segment, it does not describe the usage of the
+extension identifier as a path segment which may have child path
+segments. This document updates [@!RFC9082] to allow the usage of
+extension identifiers as path segments which may have child path
+segments. For example, if the "foobar" extension defines the child
+paths "fizz" and "fazz", the URLs for this extension would be like so:
 
     https://base.example/foobar/fizz
     https://base.example/foobar/fazz
 
-Extensions defining new URI paths MUST explicitly define the expected response
-to each new URI path. New URI paths may return existing object classes or search
-results as defined in [@!RFC9083], object classes or search results defined by
-the extension (see (#object_classes_in_extensions) and (#search_results_in_extensions)
+Extensions defining new URL paths MUST explicitly define the expected
+responses for each new URL path. New URL paths may return existing
+object classes or search results as defined in [@!RFC9083], object
+classes or search results defined by the extension (see
+(#object_classes_in_extensions) and (#search_results_in_extensions)
 below), or object classes or search results from other extensions.
 
-Although [@!RFC9082] describes the use of URI query strings, it does not define
-their use with extensions. [@!RFC7480] instructs servers to ignore unknown query
-parameters. Therefore, the use of query parameters, prefixed or not with an
-extension identifier, is undefined as defined in [@!RFC9082] and [@!RFC7480]. 
+### Usage in Query Parameters {#usage_in_query_parameters}
 
-Despite this, there are several extensions that do specify query parameters.
-This document updates [@!RFC9082] with regard to the use of RDAP extension
-identifiers in URL query parameters. 
+Although [@!RFC9082] describes the use of URL query strings, it does
+not define their use with extensions. [@!RFC7480] instructs servers to
+ignore unknown query parameters. Therefore, the use of query
+parameters, whether prefixed with an extension identifier or not, is
+not supported by [@!RFC9082] and [@!RFC7480].
 
-When an RDAP extension defines query parameters to be used with a URL path
-that is not defined by that RDAP extension, those query parameter names SHOULD be 
-constructed in the same manner as URL path segments (that is, extensions ID + '_' 
-+ parameter name). See section (#extension_classes) regarding when usage of an 
-extension identifier is required.
+Despite this, there are several extensions that do specify query
+parameters.  This document updates [@!RFC9082] with regard to the use
+of RDAP extension identifiers in URL query parameters.
 
-When an RDAP extension defines query parameters to be used with a URL path defined
-by that RDAP extension, prefixing of query parameters is not required.
+When an RDAP extension defines query parameters to be used with a URL
+path that is not defined by that RDAP extension, those query parameter
+names SHOULD be constructed in the same manner as URL path segments
+(that is, extension identifier + '_' + parameter name).  (See section
+(#identifier_omission) regarding when an extension identifier may be
+omitted.)
 
-See (#redirects) and (#referrals) for other guidance on the use of query
-parameters, and see (#security_considerations) and (#privacy_considerations)
-regarding the constraints on the usage of query parameters. 
+When an RDAP extension defines query parameters to be used with a URL
+path defined by that RDAP extension, prefixing of query parameters is
+not required.  In this situation, the URL path operates as a namespace
+for the query parameters, so there is no risk of collision with
+parameters defined elsewhere.
 
-# Usage in JSON {#usage_in_json}
+See (#redirects_author) and (#referrals) for other guidance on the use of
+query parameters, and see (#security_considerations) and
+(#privacy_considerations) regarding constraints on the usage of query
+parameters.
 
-[@!RFC9083, section 2] describes the use of extension identifiers in the JSON
-returned by RDAP servers. Just as in URIs, the extension identifier is prepended
-to JSON names to create a namespace so that the JSON name from one extension
-will not collide with the JSON name of another extension. And just as with
-unknown query parameters in URIs, clients are to ignore unknown JSON names.
+## Usage in Responses {#usage_in_responses}
+
+### Basic Requirements {#usage_in_responses}
+
+[@!RFC9083, section 2] describes the use of extension identifiers in
+the JSON returned by RDAP servers. Just as in URLs, the extension
+identifier is prepended to JSON names to create a namespace so that
+the JSON name from one extension will not collide with the JSON name
+from another extension. Just as with unknown query parameters in URLs,
+clients are to ignore unknown JSON names.
 
 The example given in [@!RFC9083] is as follows:
 
@@ -216,16 +308,16 @@ The example given in [@!RFC9083] is as follows:
     }
 
 In this example, the extension identified by "lunarNIC" is prepended
-to the names of both a JSON string and a JSON array.
+to the member names of both a JSON string and a JSON array.
 
-As [@!RFC9083, section 4.1] requires the use of the `rdapConformance` data structure
-and the `objectClassName` string is required of all object class instances,
-the complete example from above would be:
+As [@!RFC9083, section 4.1] requires the use of the "rdapConformance"
+data structure, and the "objectClassName" string is required of all
+object class instances, the complete example from above would be:
 
     {
       "rdapConformance": [
         "rdap_level_0",
-        "lunarNIC"  
+        "lunarNIC"
       ],
       "objectClassName": "domain",
       "handle": "ABC123",
@@ -248,17 +340,17 @@ the complete example from above would be:
       ]
     }
 
-## Child JSON Values {#child_json_values}
+### Child JSON Values {#child_json_values}
 
-Prefixing of the extension identifier is not required of children of a prefixed
-JSON object defined by an RDAP extension.
+Prefixing of the extension identifier is not required for children of
+a prefixed JSON object defined by an RDAP extension.
 
-The following example shows this use with a JSON object.
+The following example shows this use with a JSON object:
 
     {
       "rdapConformance": [
         "rdap_level_0",
-        "lunarNIC"  
+        "lunarNIC"
       ],
       "objectClassName": "domain",
       "ldhName": "example.com",
@@ -281,24 +373,27 @@ The following example shows this use with a JSON object.
 
 Here the JSON name "lunarNIC_author" will separate the JSON from other
 extensions that may have an "author" structure. But the JSON contained
-within "lunarNIC_author" need not be prepended as the extension collision
-is avoided by "lunarNIC_author".
+within "lunarNIC_author" need not be prepended, as collision is
+avoided by the use of "lunarNIC_author".
 
-## Object Classes in Extensions {#object_classes_in_extensions}
+### Object Classes in Extensions {#object_classes_in_extensions}
 
-As described in [@!RFC9082] and (#usage_in_queries), an extension may define new paths in URIs.
-If the extension describes the behavior of an RDAP query using that path to return a new RDAP
-object class, the JSON names are not required to be prepended with the extension identifier
-as described in (#child_json_values). However, the extension MUST define the value for the
-`objectClassName` string which is used by clients to evaluate the type of the response. 
-To avoid collisions with object classes defined in other extensions, the value for the 
-`objectClassName` MUST either be prepended with the extension identifier or
-be the extension identifier in cases where the extension defines only one object class.
+As described in [@!RFC9082] and (#usage_in_requests), an extension may
+define new paths in URLs.  If the extension describes the behavior of
+an RDAP query using that path to return an instance of a new class of
+RDAP object, the JSON names are not required to be prepended with the
+extension identifier as described in (#child_json_values). However,
+the extension MUST define the value for the "objectClassName" string
+which is used by clients to evaluate the type of the response.  To
+avoid collisions with object classes defined in other extensions, the
+value for the "objectClassName" MUST be prepended with the extension
+identifier, in the same way as for URL paths, query parameters, and
+JSON names:
 
     {
       "rdapConformance": [
         "rdap_level_0",
-        "lunarNIC"  
+        "lunarNIC"
       ],
       "objectClassName": "lunarNIC_author",
       "author":
@@ -308,29 +403,31 @@ be the extension identifier in cases where the extension defines only one object
       }
     }
 
+It is RECOMMENDED that object class names comprise lowercase ASCII
+characters, and that the "\_" (underscore) character be used as a word
+separator.  Though "objectClassName" is a string and [@!RFC9083] does
+define one object class name with a space separator (i.e. "ip
+network"), usage of the space character or any other character that
+requires URL-encoding is NOT RECOMMENDED.  When object class names are
+also used in URLs, extensions MUST specify that the names are to be
+URL-encoded as defined in [@!RFC3986] if the object class names
+contain any characters requiring URL-encoding.
 
-It is RECOMMENDED that object class names be lowercased, ASCII characters
-that use the "\_" (underscore) character as a word separator.
-Though `objectClassName` is a string and [@!RFC9083] does define
-one object class name with a space separator (i.e. "ip network"), usage of the space character or
-any whitespace or any other character that requires URL-encoding is NOT RECOMMENDED.
-When object class names are also used in URIs, extensions MUST specify that the names
-are to be URL-encoded as defined in [@!RFC3986] if the object class names contain any
-characters requiring URL-encoding.
+### Search Results in Extensions {#search_results_in_extensions}
 
-## Search Results in Extensions {#search_results_in_extensions}
-
-As described in [@!RFC9082] and (#usage_in_queries), an extension may define new paths in URIs.
-If the extension describes the behavior of an RDAP query using the path to return a new RDAP
-search result, the JSON name of the search result MUST be prepended with the extension identifier
-(to avoid collision with search results defined in other extensions).
-If the search result contains object class instances defined by the extension, each instance
-must have an `objectClassName` string as defined in (#object_classes_in_extensions).
+As described in [@!RFC9082] and (#usage_in_requests), an extension may
+define new paths in URLs.  If the extension describes the behavior of
+an RDAP query using the path to return a new RDAP search result, the
+JSON name of the search result MUST be prepended with the extension
+identifier (to avoid collision with search results defined in other
+extensions).  If the search result contains object class instances
+defined by the extension, each instance must have an "objectClassName"
+string as defined in (#object_classes_in_extensions).  For example:
 
     {
       "rdapConformance": [
         "rdap_level_0",
-        "lunarNIC"  
+        "lunarNIC"
       ],
       "lunarNIC_authorSearchResult": [
         {
@@ -352,20 +449,21 @@ must have an `objectClassName` string as defined in (#object_classes_in_extensio
       ]
     }
 
-## Bare Extension Identifiers {#bare_extension}
+### Bare Extension Identifiers {#bare_extension}
 
-Some RDAP extensions define only one JSON value and do not prefix it with their
-RDAP extension identifier; instead using the extension identifier as the JSON name
-for that JSON value. That is, the extension identifier is used "bare" and not appended
-with an underscore character and subsequent names.
+Some RDAP extensions define only one JSON value and do not prefix it
+with their RDAP extension identifier, instead using the extension
+identifier as the JSON name for that JSON value. That is, the
+extension identifier is used "bare" and not appended with an
+underscore character and subsequent names.
 
-Consider the example in (#child_json_values). Using the bare extension identifier pattern,
-that example could be written as:
+Consider the example in (#child_json_values). Using the bare extension
+identifier pattern, that example could be written as:
 
     {
       "rdapConformance": [
         "rdap_level_0",
-        "lunarNIC"  
+        "lunarNIC"
       ],
       "objectClassName": "domain",
       "ldhName": "example.com",
@@ -386,125 +484,187 @@ that example could be written as:
       }
     }
 
-Usage of a bare extension identifier contravenes the guidance in [@!RFC9083].
-This document updates [@!RFC9083] to explicitly allow this pattern.
+Usage of a bare extension identifier contravenes the guidance in
+[@!RFC9083].  This document updates [@!RFC9083] to explicitly allow
+this pattern.
 
-# Camel Casing {#camel_casing}
+Along similar lines, an extension may define a single new object
+class, and use the extension's identifier as the object class name.
 
-The styling convention used in [@!RFC9083] for JSON names is often called
-"camel casing", in reference to the hump of a camel. In this style, the 
-first letter of every word, except the first word, composing a name is capitalized.
-This convention was adopted to visually separate the namespace from the
-name, with an underscore between them.
+### rdapConformance population
 
-Though there is no explicit guidance to use camel case names, extensions would
-be wise to continue the style.
+[@!RFC9083, Section 4.1] offers the following guidance on including
+extension identifiers in the "rdapConformance" member of an RDAP
+response:
 
-# Two Classes of Extensions {#extension_classes}
+    A response to a "help" request will include identifiers for all of
+    the specifications supported by the server. A response to any
+    other request will include only identifiers for the specifications
+    used in the construction of the response.
 
-Though all RDAP extensions are to be registered in the IANA RDAP extensions
-registry, there is an implicit two-class system of extensions that comes from
-the inherit ownership of the RDAP specifications by the IETF: extensions
-created by the IETF and extensions not created by the IETF.
+A strict interpretation of this wording where "construction of the
+response" refers to the JSON structure only would rule out the use of
+(#profiles_and_markers) extension identifiers, which are in common use
+in RDAP.  This document updates the guidance. For responses to queries
+other than "/help", a response MUST include in the "rdapConformance"
+array only those extension identifiers necessary for a client to
+deserialize the JSON and understand the semantic meaning of the
+content within the JSON, and each extension identifier MUST be free
+from conflict with the other identifiers with respect to their syntax
+and semantics.
 
-In the perspective of how extensions identifiers are used as namespace
-separators, extensions created by the IETF are not required to be prefixed
-with an extension identifier as the IETF can coordinate its own activities
-to avoid name collisions. In practice, most extensions owned by the IETF do use
-extension identifiers.
+Note that this document does not update the guidance from [@!RFC9083,
+Section 4.1] regarding "/help" responses and the "rdapConformance"
+array.
 
-RDAP extensions not defined by the IETF MUST use the extension identifier
-as a prefix in accordance with this document, [@!RFC7480], [@!RFC9082], and
-[@!RFC9083]. And RDAP extensions defined by the IETF SHOULD use the extension
-identifier as a prefix or as a bare extension identifier (see (#bare_extension)).
-IETF-defined RDAP extensions that do not follow this guidance MUST describe
-the necessity to do so.
+### Camel Casing {#camel_casing}
+
+The styling convention used in [@!RFC9083] for JSON names is often
+called "camel casing", in reference to the hump of a camel. In this
+style, the first letter of every word, except the first word,
+composing a name is capitalized.  This convention was adopted to
+visually separate the namespace from the name, with an underscore
+between them.  Though there is no explicit guidance to use camel case
+names, extensions would be wise to continue the style.
+
+## Identifier Omission {#identifier_omission}
+
+Though all RDAP extensions are to be registered in the IANA RDAP
+extensions registry, there is an implicit two-class system of
+extensions that comes from the ownership of the RDAP specifications by
+the IETF: extensions created by the IETF and extensions not created by
+the IETF.
+
+In the perspective of how extension identifiers are used as namespace
+separators, extensions created by the IETF are not required to use the
+extension identifier as a prefix in requests and responses, as the
+IETF can coordinate its own activities to avoid name collisions. In
+practice, most extensions owned by the IETF do use extension
+identifiers as prefixes in their requests and responses.
+
+RDAP extensions not defined by the IETF MUST use the extension
+identifier as a prefix in accordance with this document, [@!RFC7480],
+[@!RFC9082], and [@!RFC9083].  RDAP extensions defined by the IETF
+SHOULD use the extension identifier as a prefix or as a bare extension
+identifier (see (#bare_extension)).  IETF-defined RDAP extensions that
+do not follow this guidance MUST describe why it is not being
+followed.
 
 In addition, RDAP extensions defined by the IETF are allowed to define
-new types in the RDAP JSON Values Registry (see (#rdap_json_values_registry)).
+new types in the RDAP JSON Values Registry (see
+(#rdap_json_values_registry)).
 
-# Profile and Marker Extensions {#profiles_and_markers}
+# Extension Implementer Considerations {#extension_implementer_considerations}
 
-Extensions are not required to extend the JSON or URL components of RDAP.
+## Redirects {#redirects_implementer}
 
-While the RDAP extension mechanism was created to extend RDAP queries
-and/or responses, extensions can also be used to signal server policy 
-(for example, specifying the conditions of use for existing
-response structures). Extensions that are primarily about signaling
-server policy are often called "profiles".
+[@!RFC7480] describes the use of redirects in RDAP. Redirects are prominent
+in the discovery of authoritative RIR servers, as the process outlined in
+[@!RFC9224], which uses IANA allocations, does not account for transfers of
+resources between RIRs. [@!RFC7480, Section 4.3] instructs servers to ignore
+unknown query parameters. As it relates to issuing URLs for redirects, servers
+MUST NOT blindly copy query parameters from a request to a redirect URL as
+query parameters may contain sensitive information, such as security credentials,
+not relevant to the target server of the URL. Following the advice in [@!RFC7480],
+servers SHOULD only place query parameters in redirect URLs when it is known
+by the origin server (the server issuing the redirect) that the target server
+(the server referenced by the redirect) can process the query parameter and the
+contents of the query parameter are appropriate to be received by the target.
 
-Some extensions exist to denote the usage of values placed into an
-IANA registry, such as the IANA RDAP registries, or the usage of extensions
-for specifications used in RDAP responses such as extended vCard/jCard properties.
-Such extensions exist to "mark" these usages and are often called "marker"
-extensions.
+# Extension Author Considerations {#extension_author_considerations}
 
-For example, an extension may be used to signal desired processing of
-a `rel` attribute in a "links" array, where the `rel` value is registered in
-the Link Relations Registry (<https://www.iana.org/assignments/link-relations/link-relations.xhtml>).
+## Redirects {#redirects_author}
+
+As it is unlikely that every server in a cross-authority, redirect
+scenario will be upgraded to process every new extension, extensions
+should not rely on query parameters alone to convey information about
+a resource, as query parameters are not guaranteed to survive a
+redirect.
+
+This does not mean extensions are prohibited from using query
+parameters, but rather that the use of query parameters must be
+applied for the scenarios appropriate for the use of the extension.
+Therefore, extensions SHOULD NOT rely on query parameters when the
+extension is to be used in scenarios requiring clients to find
+authoritative servers, such as that described above, or other
+scenarios using redirects among servers of differing authorities.
+
+Extensions MAY use query parameters in scenarios where the client has
+a priori knowledge of the authoritative server to which queries are to
+be sent, and will be sending queries to that server directly.
+Searches ([@!RFC9083, section 8]) are an example scenario where a
+client will be operating in this way.
+
+In general, extension authors should be mindful of situations
+requiring clients to directly handle redirects at the RDAP layer. Some
+clients may not be utilizing HTTP libraries that provide such an
+option, and many HTTP client libraries that do provide the option do
+not provide it as a default behavior. Additionally, requiring clients
+to handle redirects at the RDAP layer adds complexity to the client in
+that additional logic must be implemented to handle redirect loops,
+parameter deconfliction, and URL encoding. The guidance given in
+[@!RFC7480, section 5.2] exists to simplify clients, especially those
+constructed with shell scripts and HTTP command-line utilities.
+
+## Referrals {#referrals}
+
+It is common in the RDAP ecosystem to link from one RDAP resource to
+another, such as can be found in domain registrations in gTLD DNRs.
+These are typically conveyed in the link structure defined in
+[@!RFC9083, section 4.2] and use the "application/rdap+json" media
+type.  For example:
 
     {
-      "rdapConformance": [
-        "rdap_level_0",
-        "lunarNIC"  
-      ],
-      "objectClassName": "domain",
-      "ldhName": "example.com",
-      "links": [
-        {
-          "value": "https://example.com/domain/example.com",
-          "href": "https://example.com/sideways_href",
-          "rel": "sideways",
-          "type": "application/rdap+json"
-        }
-      ]
+      "value": "https://regy.example/domain/foo.example",
+      "rel": "related",
+      "href": "https://regr.example/domain/foo.example",
+      "type": "application/rdap+json"
     }
 
-When defining the usage link relations, extensions should specify the
-media types expected to be used with those link relations.
+Extensions MUST explicitly define any required behavioral changes to
+the processing of referrals.  If an extension does not make any
+provision in this respect, clients MUST assume the information
+provided by referrals requires no additional processing or
+modification to use in the dereferencing of the referral.
 
-Regardless of the category of these extensions, their usage may also
-leverage the appearance of their identifiers in the `rdapConformance` array.
-Clients may use the `/help` query as defined in [@!RFC9082] to discover
-the extensions available. 
+## Extension Versioning {#versioning}
 
-# Extension Versioning
-
-As stated in (#extension_identifier), RDAP extensions are opaque, and
+As stated in (#purpose), RDAP extensions are opaque, and
 they possess no explicit version despite the fact that some extension
 identifiers include trailing numbers. That is, RDAP extensions without
-an explicitly defined versioning scheme are opaquely versioned.
+an explicitly-defined versioning scheme are opaquely versioned.
 
-For example, `fizzbuzz_1` may be the successor to `fizzbuzz_0`, but it
-may also be an extension for a completely separate purpose. Only consultation
-of the definition of `fizzbuzz_1` will determine its relationship with
-`fizzbuzz_0`. Additionally, `fizzbuzz_99` may be the predecessor of `fizzbuzz_0`.
+For example, "fizzbuzz_1" may be the successor to "fizzbuzz_0", but it
+may also be an extension for a completely separate purpose. Only
+consultation of the definition of "fizzbuzz_1" will determine its
+relationship with "fizzbuzz_0". Additionally, "fizzbuzz_99" may be the
+predecessor of "fizzbuzz_0".
 
 If a future RFC defines a versioning scheme (such as using the
-mechanism defined in (#extension_identifier)), an RDAP extension
-definition MUST explicitly denote this compliance.
+mechanism defined in (#purpose)), an RDAP extension definition MUST
+explicitly denote its compliance with that scheme.
 
-## Backwards-Compatible Changes {#backwards_compatible_changes}
+### Backwards-Compatible Changes {#backwards_compatible_changes}
 
 If an RDAP extension author wants to publish a new version of an
 extension that is backwards-compatible with the previous version, then
 one option is for the new version of the extension to define a new
 identifier, as well as requiring that both the previous identifier
-and the new identifier be included in the "rdapConformance" array of 
-responses.  That way, clients relying on the previous version of the 
-extension will continue to function as intended, while clients wanting 
-to make use of the newer version of the extension can check for the new 
+and the new identifier be included in the "rdapConformance" array of
+responses.  That way, clients relying on the previous version of the
+extension will continue to function as intended, while clients wanting
+to make use of the newer version of the extension can check for the new
 identifier in the response.
 
 This approach can be used for an arbitrary number of new
 backwards-compatible versions of a given extension.  For an extension
 with a large number of backwards-compatible successor versions, this
-may lead to a large number of identifiers being included in
-responses.  An extension author may consider excluding older
-identifiers from the set required by new successor versions,
-based on data about client use/support or similar.
+may lead to a large number of identifiers being included in responses.
+An extension author may consider excluding older identifiers from the
+set required by new successor versions, based on data about client
+use/support or similar.
 
-## Backwards-Incompatible Changes {#backwards_incompatible_changes}
+### Backwards-Incompatible Changes {#backwards_incompatible_changes}
 
 With the current extension model, an extension with a
 backwards-incompatible change is indistinguishable from a new,
@@ -522,52 +682,41 @@ following:
  - whether the extension itself should define how versioning is
    handled within the extension documentation.
 
-# Extension Identifiers in a Response
+## Extension Specification Content
 
-Extension specifications have customarily defined only one extension identifier. However,
-there is no explicit limit on the number of extension identifiers that may be defined in
-a single extension specification. One example is [@?I-D.ietf-regext-rdap-rir-search].
+The primary purpose of an RDAP extension specification is to aid in
+the implementation of RDAP clients. Extension authors should consider
+the following content guidelines:
 
-[@!RFC9083, Section 4.1] offers the following guidance on using the extension identifiers
-in RDAP responses:
+1. Examples of RDAP JSON should be generously given, especially in
+areas of the specification which may be complex or difficult to describe
+with prose.
+2. Normative references, i.e. references to materials that are
+required for the interoperability of the extension, should be stable
+and non-changing.
+3. Extension specifications should strongly consider making the use
+of HTTPS with RDAP mandatory if appropriate.
 
-    A response to a "help" request will include identifiers for all of the specifications
-    supported by the server. A response to any other request will include only identifiers 
-    for the specifications used in the construction of the response.
+## Extension Definitions
 
-A strict interpretation of this wording where "construction of the response" only refers
-to the JSON syntax would rule out the usage of (#profiles_and_markers) extension IDs which
-are in common use in RDAP. This document updates the guidance. For responses to queries
-other than "help", a response MUST include in the `rdapConformance` array only those extension
-identifiers necessary for a client to deserialize the JSON and understand the semantic meaning
-of the content within the JSON, and all extensions identifiers MUST be free from conflict in
-both their syntactic and semantic meaning.
+Extensions must be documented in an RFC or in some other permanent and
+readily available reference, in sufficient detail that
+interoperability between independent implementations is possible.
 
-Note that this document does not update the guidance from [@!RFC9083, Section 4.1] regarding
-"help" responses and the `rdapConformance` array.
+Though RDAP gives each extension its own namespace, the definition of
+an extension may reuse definitions found in the base RDAP
+specification or in any other registered extension.
 
-When a server implementation supports multiple extensions, it is RECOMMENDED that the server
-also support and return versioning information such as that defined by [@?I-D.gould-regext-rdap-versioning].
+[@!RFC9083] notes that the extension identifiers provide a "hint" to
+the client as to how to interpret the response. This wording does not
+intentionally restrict the extension to defining only JSON values
+within the extension's namespace.  Therefore, an extension may define
+the use of its own JSON values together with the use of JSON values
+from other extensions or RDAP specifications. As with the ICANN
+profile or NRO profile extensions, the extension may simply signal
+policy applied to previously-defined RDAP structures.
 
-# Extension Definitions
-
-Extensions must be documented in an RFC or in some other permanent and readily
-available reference, in sufficient detail that interoperability between independent 
-implementations is possible.
-
-Though RDAP gives each extension its own namespace, the definition of an
-extension may re-use definitions found in the base RDAP specification or in any
-other properly registered extension.
-
-[@!RFC9083] notes that the extension identifiers provide a "hint" to the client
-as to how to interpret the response. This wording does not intentionally restrict
-the extension to defining only JSON values within the extensions' namespace.
-Therefore, an extension may define the use of its own JSON values together
-with the use of JSON values from other extensions or RDAP specifications. As with
-the ICANN profile or NRO profile extensions, the extension may simply signal 
-policy applied to already defined RDAP structures.
-
-# Existing Extension Registrations
+# Existing Extension Registrations {#existing_extension_registrations}
 
 The following extensions have been registered with IANA, but do not
 comply with the requirements set out in the base specifications, as
@@ -599,84 +748,6 @@ extension registration that attempts to use one of the RDAP
 conformance values given in this section as an extension identifier
 (and so as an RDAP conformance value also) will be rejected.
 
-# Redirects {#redirects}
-
-[@!RFC7480] describes the use of redirects in RDAP. Redirects are prominent
-in the discovery of authoritative RIR servers as the process outlined in
-[@?RFC9224], which uses IANA allocations, does not account for transfers of
-resources between RIRs. [@!RFC7480, Section 4.3] instructs servers to ignore
-unknown query parameters. As it relates to issuing URLs for redirects, servers
-MUST NOT blindly copy query parameters from a request to a redirect URL as
-query parameters may contain sensitive information, such as security credentials,
-not relevant to the target server of the URL. Following the advice in [@!RFC7480],
-servers SHOULD only place query parameters in redirect URLs when it is known
-by the origin server (the server issuing the redirect) that the target server
-(the server referenced by the redirect) can process the query parameter and the
-contents of the query parameter are appropriate to be received by the target.
-
-As it is unlikely that every server in a cross-authority, redirect scenario will be upgraded to process
-every new extension, extensions should not solely rely on query parameters to convey
-information about a resource as query parameters are not guaranteed to survive a redirect.
-
-This does not mean extensions are prohibited from using query parameters, but
-rather that the use of query parameters must be applied for the scenarios appropriate
-for the use of the extension. Therefore, extensions SHOULD NOT rely on query parameters
-when the extension is to be used in scenarios requiring clients to find authoritative
-servers, such as that described above, or other scenarios using redirects among 
-servers of differing authorities.
-
-Extensions MAY use query parameters
-in scenarios where the client has a priori knowledge of the authoritative
-server to which queries are to be sent. Such scenarios are generally queries
-intended to yield multiple results, authentication or authorization,
-and other scenarios where the behavior of requests across multiple authorities 
-is undefined.
-
-In general, extension authors should be mindful of situations requiring clients
-to directly handle redirects at the RDAP layer. Some clients may not be utilizing
-HTTP libraries that provide such an option, and many HTTP client libraries that
-do provide the option do not provide it as a default behavior. Additionally,
-requiring clients to handle redirects at the RDAP layer adds complexity to the
-client in that additional logic must be implemented to handle redirect loops,
-parameter deconfliction, and URL encoding. The guidance given in [@!RFC7480, section 5.2]
-exists to simplify clients, especially those constructed with shell scripts
-and HTTP command-line utilities.
-
-# Referrals {#referrals}
-
-It is common in the RDAP ecosystem to link from one RDAP resource to another, 
-such as can be found in domain registrations in gTLD DNRs.
-These are typically conveyed in the link structure defined in 
-[@?RFC9083, section 4.2] and use the "application/rdap+json"
-media type.
-
-    {
-      "value": "https://regy.example/domain/foo.example",
-      "rel": "related",
-      "href": "https://regr.example/domain/foo.example",
-      "type": "application/rdap+json"
-    }
-
-Extensions MUST explicitly define any required behavioral changes to the
-processing of referrals, otherwise clients MUST assume the information
-provided by referrals requires no additional processing or modification to
-use in the dereferencing of the referral.
-
-# Extension Specification Content
-
-The primary purpose of an RDAP extension specification is to aid in
-the implementation of RDAP clients. These specifications should consider
-the following content guidelines:
-
-1. Examples of RDAP JSON should be generously given, especially in
-areas of the specification which may be complex or difficult to describe
-with prose.
-2. Normative references, i.e. references to materials that are
-required for the interoperability of the extension, should be stable
-and non-changing.
-3. Extension specifications should strongly consider making the use
-of HTTPS with RDAP mandatory if appropriate.
-
 # IANA Considerations
 
 ## RDAP Extensions Registry {#rdap_extensions_registry}
@@ -687,24 +758,24 @@ document does update the procedures to be used by its expert reviewers.
 
 The RDAP Extensions Registry should have as a minimum three expert reviewers
 and ideally four or five. An expert reviewer assigned to the review of an RDAP
-extension registration must have another expert reviewer double check any
+extension registration must have another expert reviewer double-check any
 submitted registration.
 
-Expert reviewers are to use the following criteria for extensions defined
-in this document, which include but are not limited to:
+Expert reviewers are to use the following criteria for extensions
+defined in this document, which include but are not limited to:
 
 1. Does the extension define an extension identifier following the naming
-conventions described in (#extension_identifier) and (#camel_casing)? For
+conventions described in (#purpose) and (#camel_casing)? For
 any recommendations regarding naming conventions (guidance given using
 RECOMMENDED, SHOULD, etc.), does the extension describe the need for
 departing from the established convention?
 2. If the extension defines new queries, does it clearly describe the
 expected results of each new query?
-3. Does the extension follow the JSON naming as described in (#usage_in_json)?
+3. Does the extension follow the JSON naming requirements as described in (#usage_in_responses)?
 4. If the extension is a newer version of an older extension, does
 the extension specification clearly describe if it is backwards-compatible
 (see (#backwards_compatible_changes)) or backwards-incompatible
-(see (#backwards_incompatible_changes)).
+(see (#backwards_incompatible_changes))?
 5. If the extension registers new values in an IANA registry used by RDAP,
 does it describe how a client is to use those values?
 
@@ -716,7 +787,7 @@ of their extension by sending a request for review to regext@ietf.org.
 [@!RFC9083, Section 10.2] defines the [RDAP JSON Values Registry in IANA]
 (https://www.iana.org/assignments/rdap-json-values/rdap-json-values.xhtml).
 This registry contains values to be used in the JSON values of RDAP responses.
-Registrations into this registry may occur in IETF defined RDAP extensions
+Registrations into this registry may occur in IETF-defined RDAP extensions
 or via requests to the IANA. Authors of RDAP extensions not defined by the
 IETF MAY register values in this registry via requests to the IANA.
 
@@ -724,24 +795,24 @@ This document does not change the RDAP JSON Values Registry nor its purpose.
 However, this document does update the procedures for registrations and the
 processes to be used by its expert reviewers.
 
-In addition to the registration of values, RDAP extensions defined by the IETF
-and other IETF specifications MAY define additional value types (the "type" field), 
-however these specifications MUST describe the specific JSON field to be used 
-for each new value type. 
+In addition to the registration of values, RDAP extensions defined by
+the IETF and other IETF specifications MAY define additional value
+types (the "type" field).  These specifications MUST describe the
+specific JSON field to be used for each new value type.
 
-[@!RFC9083, Section 10.2] defines the criteria for the values. Of these, criteria two (#2)
+[@!RFC9083, Section 10.2] defines the criteria for the values. Of these, criteria two (\#2)
 states:
 
-> Values must be strings. They should be multiple words separated by single 
-> space characters. Every character should be lowercased. If possible, every 
+> Values must be strings. They should be multiple words separated by single
+> space characters. Every character should be lowercased. If possible, every
 > word should be given in English and each character should be US-ASCII.
 
-All registrations SHOULD meet these requirements, however there may be scenarios
-in which it is more appropriate for the values to follow other requirements
-such as values also used in other specifications or documents. In all cases,
+All registrations SHOULD meet these requirements. However, there may be scenarios
+in which it is more appropriate for the values to follow other
+requirements, such as for values also used in other specifications or documents. In all cases,
 it should be understood that additional registrations of RDAP JSON values occurring
 after the specification of the value's type in the registry may not be
-recognized by clients and therefore either ignored or passed on to users
+recognized by clients, and therefore either ignored or passed on to users
 without processing.
 
 Designated experts MUST reject any registration that is a duplicate of an
@@ -752,20 +823,20 @@ should be rejected.
 RDAP clients SHOULD match values in this registry using case-insensitive matching.
 
 Definitions of new types (see above) MAY additionally constrain the format of
-values for those new types beyond the specification of this document and [@!RFC9083]. 
+values for those new types beyond the specification of this document and [@!RFC9083].
 Designated experts MUST evaluate registrations with those criteria.
 
 The RDAP JSON Values Registry should have as a minimum three expert reviewers
 and ideally four or five. An expert reviewer assigned to the review of an RDAP
-JSON values registration must have another expert reviewer double check any
+JSON values registration must have another expert reviewer double-check any
 submitted registration.
 
 Expert reviewers are to use the criteria defined in [@!RFC9083, Section 10.2].
 
 # Security Considerations {#security_considerations}
 
-(#usage_in_queries) describes the usage of query parameters and (#redirects) describes
-the restrictions extensions must follow to use them. 
+(#usage_in_query_parameters) describes the usage of query parameters and (#redirects_author) describes
+the restrictions extensions must follow to use them.
 [@!RFC7480, Section 4.3] instructs servers to ignore
 unknown query parameters. As it relates to issuing URLs for redirects, servers
 MUST NOT blindly copy query parameters from a request to a redirect URL as
@@ -778,12 +849,13 @@ contents of the query parameter are appropriate to be received by the target.
 
 # Privacy Considerations {#privacy_considerations}
 
-(#usage_in_queries) describes the usage of query parameters and (#redirects) describes
-the restrictions extensions must follow to use them. As query parameters have been
-known to be used to subvert the privacy preferences of users in HTTP using protocols,
-server MUST NOT blindly copy query parameters from a request to a redirect URL
-as described in (#security_considerations) and extensions MUST follow the
-constraints of query parameter usage as defined in (#redirects).
+(#usage_in_query_parameters) describes the usage of query parameters
+and (#redirects_author) describes the restrictions extensions must follow to
+use them. As query parameters have been known to be used to subvert
+the privacy preferences of users in HTTP-based protocols, server MUST
+NOT blindly copy query parameters from a request to a redirect URL as
+described in (#security_considerations) and extensions MUST follow the
+constraints of query parameter usage as defined in (#redirects_author).
 
 # Acknowledgments
 

--- a/draft-regext-rdap-extensions.md
+++ b/draft-regext-rdap-extensions.md
@@ -529,7 +529,7 @@ style, the first letter of every word, except the first word,
 composing a name is capitalized.  This convention was adopted to
 visually separate the namespace from the name, with an underscore
 between them.  Extension authors SHOULD use camel casing for JSON
-names defined in extensions. 
+names defined in extensions.
 
 ## Identifier Omission {#identifier_omission}
 

--- a/draft-regext-rdap-extensions.md
+++ b/draft-regext-rdap-extensions.md
@@ -78,7 +78,7 @@ areas:
 1. (#extension_implementer_considerations) documents behavior
    considerations for extension implementers.
 1. (#extension_author_considerations) documents behavior
-   considerations for extension developers, covering
+   considerations for extension authors, covering
    redirects ((#redirects_author)), referrals ((#referrals)), and versioning
    ((#versioning)).
 1. (#existing_extension_registrations) documents existing extensions that
@@ -172,7 +172,7 @@ specification.  The main reason for defining multiple identifiers is
 to reserve multiple namespaces in URLs or responses: see e.g.
 [@?I-D.ietf-regext-rdap-rir-search].
 
-## Syntax
+## Syntax {#syntax}
 
 In brief, RDAP extension identifiers start with an alphabetic
 character and may contain alphanumeric characters and "_" (underscore)
@@ -421,7 +421,7 @@ an RDAP query using the path to return a new RDAP search result, the
 JSON name of the search result MUST be prepended with the extension
 identifier (to avoid collision with search results defined in other
 extensions).  If the search result contains object class instances
-defined by the extension, each instance must have an "objectClassName"
+defined by the extension, each instance MUST have an "objectClassName"
 string as defined in (#object_classes_in_extensions).  For example:
 
     {
@@ -491,7 +491,7 @@ this pattern.
 Along similar lines, an extension may define a single new object
 class, and use the extension's identifier as the object class name.
 
-### rdapConformance population
+### rdapConformance Population
 
 [@!RFC9083, Section 4.1] offers the following guidance on including
 extension identifiers in the "rdapConformance" member of an RDAP
@@ -513,9 +513,13 @@ content within the JSON, and each extension identifier MUST be free
 from conflict with the other identifiers with respect to their syntax
 and semantics.
 
-Note that this document does not update the guidance from [@!RFC9083,
-Section 4.1] regarding "/help" responses and the "rdapConformance"
-array.
+Note that this document does not update the guidance from [@!RFC9083, Section 4.1]
+regarding "/help" responses and the "rdapConformance" array.
+
+When a server implementation supports multiple extensions, it is
+RECOMMENDED that the server also support and return versioning
+information such as that defined by
+[@?I-D.gould-regext-rdap-versioning].
 
 ### Camel Casing {#camel_casing}
 
@@ -524,13 +528,13 @@ called "camel casing", in reference to the hump of a camel. In this
 style, the first letter of every word, except the first word,
 composing a name is capitalized.  This convention was adopted to
 visually separate the namespace from the name, with an underscore
-between them.  Though there is no explicit guidance to use camel case
-names, extensions would be wise to continue the style.
+between them.  Extension authors SHOULD use camel casing for JSON
+names defined in extensions. 
 
 ## Identifier Omission {#identifier_omission}
 
 Though all RDAP extensions are to be registered in the IANA RDAP
-extensions registry, there is an implicit two-class system of
+Extensions Registry, there is an implicit two-class system of
 extensions that comes from the ownership of the RDAP specifications by
 the IETF: extensions created by the IETF and extensions not created by
 the IETF.
@@ -586,8 +590,8 @@ parameters, but rather that the use of query parameters must be
 applied for the scenarios appropriate for the use of the extension.
 Therefore, extensions SHOULD NOT rely on query parameters when the
 extension is to be used in scenarios requiring clients to find
-authoritative servers, such as that described above, or other
-scenarios using redirects among servers of differing authorities.
+authoritative servers, or other scenarios using redirects among
+servers of differing authorities.
 
 Extensions MAY use query parameters in scenarios where the client has
 a priori knowledge of the authoritative server to which queries are to
@@ -641,7 +645,7 @@ relationship with "fizzbuzz_0". Additionally, "fizzbuzz_99" may be the
 predecessor of "fizzbuzz_0".
 
 If a future RFC defines a versioning scheme (such as using the
-mechanism defined in (#purpose)), an RDAP extension definition MUST
+mechanism defined in (#syntax)), an RDAP extension definition MUST
 explicitly denote its compliance with that scheme.
 
 ### Backwards-Compatible Changes {#backwards_compatible_changes}
@@ -712,8 +716,9 @@ the client as to how to interpret the response. This wording does not
 intentionally restrict the extension to defining only JSON values
 within the extension's namespace.  Therefore, an extension may define
 the use of its own JSON values together with the use of JSON values
-from other extensions or RDAP specifications. As with the ICANN
-profile or NRO profile extensions, the extension may simply signal
+from other extensions or RDAP specifications. As with the
+[@icann-profile]
+and [@nro-profile] extensions, the extension may simply signal
 policy applied to previously-defined RDAP structures.
 
 # Existing Extension Registrations {#existing_extension_registrations}
@@ -762,7 +767,8 @@ extension registration must have another expert reviewer double-check any
 submitted registration.
 
 Expert reviewers are to use the following criteria for extensions
-defined in this document, which include but are not limited to:
+defined in this document, [!@RFC7480], [!@RFC9082], and [!@RFC9083].
+The following is a summary checklist:
 
 1. Does the extension define an extension identifier following the naming
 conventions described in (#purpose) and (#camel_casing)? For
@@ -778,6 +784,12 @@ the extension specification clearly describe if it is backwards-compatible
 (see (#backwards_incompatible_changes))?
 5. If the extension registers new values in an IANA registry used by RDAP,
 does it describe how a client is to use those values?
+
+As noted in (#syntax), any new registration that is a case variant of
+an existing registration MUST be rejected.
+
+RDAP clients SHOULD match values in this registry using
+case-insensitive matching.
 
 Extension authors are encouraged but not required to seek an informal review
 of their extension by sending a request for review to regext@ietf.org.
@@ -864,3 +876,23 @@ content and direction of this document: James Gould, Daniel Keathley, and
 Ties de Kock.
 
 {backmatter}
+
+<reference anchor='icann-profile' target='https://www.icann.org/gtld-rdap-profile'>
+    <front>
+        <title>gTLD RDAP Profile</title>
+        <author>
+            <organization>ICANN</organization>
+        </author>
+        <date year='2024'/>
+    </front>
+</reference>
+
+<reference anchor='nro-profile' target='https://bitbucket.org/nroecg/nro-rdap-profile/raw/v1/nro-rdap-profile.txt'>
+    <front>
+        <title>NRO RDAP Profile</title>
+        <author>
+            <organization>NRO</organization>
+        </author>
+        <date year='2021'/>
+    </front>
+</reference>


### PR DESCRIPTION
Editorial/restructuring update suggestions.  Although much of the text has been moved around, the only substantive change is that the following text was removed:

```
When a server implementation supports multiple extensions, it is                                                       
RECOMMENDED that the server also support and return versioning                                                         
information such as that defined by                                                                                    
[@?I-D.gould-regext-rdap-versioning].
```

since it looks like a down reference, though maybe "such as that" helps in that respect.

The following sentence was left as-is:

```
Expert reviewers are to use the following criteria for extensions
defined in this document, which include but are not limited to:
```

but the meaning is not clear.  If e.g. it is saying that there may be other relevant criteria, then possibly something like "Expert reviewers are to use at least the following criteria for RDAP extensions:" would be better.

Also, all instances of URI were changed to URL.  9082 and 9083 are not consistent on this point, but using the more-specific term seems like a reasonable approach.

Just to avoid any doubt, I don't have any concerns with the substance of the document as at 03 (save for the two comments above), and so I'm fine with skipping this and just going to WGLC per 03.